### PR TITLE
second pass at custom metrics with full dashboard

### DIFF
--- a/elastic-search/lib/metrics.js
+++ b/elastic-search/lib/metrics.js
@@ -8,17 +8,21 @@ class GCMetrics {
     if( config.google.keyfile ) {
       this.client = new MetricServiceClient();
       this.metrics = config.metrics.definitions;
-      this.values = {};
-      this.labels = {};
+      this.labels = null;
       this.ensureMetrics();
 
-      setInterval(() => this._sendQueue(), 3000);
+      this.setGlobalLabels({instance: config.instance.name});
+
+      this.queue = {};
+
+      setInterval(() => this._sendQueue(), 5000);
     }
   }
 
   async ensureMetrics() {
     for( let key in this.metrics ) {
       let metric = this.metrics[key];
+
       await this.client.createMetricDescriptor({
         name: this.client.projectPath(config.google.projectId),
         metricDescriptor: metric
@@ -26,35 +30,47 @@ class GCMetrics {
     }
   }
 
-  setDefaultLabels(harvester, type, labels) {
-    if( !this.labels[harvester] ) {
-      this.labels[harvester] = {};
-    }
-    this.labels[harvester][type] = labels;
+  setGlobalLabels(labels) {
+    this.labels = labels;
   }
 
-  log() {
-    // apply args to labels
-    let args = Array.from(arguments);
-    let harvesterName = args.shift(1);
-    let metricName = args.shift(1);
-    let labels = args.shift(1);
+  /**
+   * @method log
+   * @description log a metrics event.  This function is due functional.  First it will console log
+   * the event, sending to stdout or stderr (if error detected).  Additionally it will stash the metric
+   * and report to Google Cloud Metrics at a regular interval.
+   * 
+   * @param {String} type metric type.  See defined types in config.metric.definitions 
+   * @param {String} labels metric labels. See defined labels for a type in config.metric.definitions 
+   * @param {String} url url for metric.  Note, this is only for logging, metrics will not contain the url 
+   * @param {Number} value metric value to record 
+   * @param {Object} opts 
+   * @param {Error} opts.error optional error object for logging
+   * @param {Error} opts.max set max value instead of accumulated value.
+   * 
+   * @returns {Promise}
+   */
+  log(type, labels, value, url, opts={}) {
     
     // ensure strings for gcs labels
     for( let key in labels ) {
       labels[key] = labels[key]+'';
     }
-    if( this.labels[harvesterName] && this.labels[harvesterName][metricName] ) {
-      labels = Object.assign(labels, this.labels[harvesterName][metricName]);
+    if( this.labels ) {
+      labels = Object.assign(labels, this.labels);
     }
-    args[0] = {labels};
-
 
     // apply logger, either error event or info log
-    if( labels?.status === 'error' ) {
-      logger.error.apply(logger, args);
-    } else {
-      logger.info.apply(logger, args);
+    if( type === config.metrics.definitions['page-index-status'].type && 
+      labels?.status === 'error' ) {
+      
+        logger.error.apply(logger, [type, labels, url, opts.error]);
+    } else if ( type === config.metrics.definitions['page-index-age'].type && 
+      value > config.metrics.indexAgeWarning ) {
+
+      logger.error.apply(logger, [`Page index age is greater than ${config.metrics.indexAgeWarning}h`, labels, value]);
+    } else if( opts.log !== false ) {
+      logger.info.apply(logger, [type, labels, url, value]);
     }
 
     // metrics only works if gcs is wired up
@@ -62,45 +78,115 @@ class GCMetrics {
       return;
     }
 
-    let key = Object.values(labels).join('-');
+    let metric = this.getMetricObject(labels, type);
 
-    if( !this.values[metricName] ) {
-      this.values[metricName] = {};
-    }
-    if( !this.values[metricName][key] ) {
-      this.values[metricName][key] = {
-        value : 0,
-        labels
+    if( Array.isArray(metric.value)) {
+      metric.value.push(value);
+    } else if ( opts.max === true ) {
+      if( metric.value < value ) {
+        metric.value = value;
       }
+    } else {
+      metric.value += value;
     }
-    this.values[metricName][key].value += 1;
+  }
+
+  addGauge(metric, value) {
+    metric.value += value;
+  }
+
+  getMetricKey(labels) {
+    return Object.values(labels).join('-');
+  }
+
+  getMetricObject(labels, type) {
+    let key = this.getMetricKey(labels);
+    let metric;
+
+    if( this.queue[type] ) {
+      metric = this.queue[type].find(metric => metric.key === key);
+      if( metric ) return metric;
+    }
+
+    let metricDef = this.getDefinitionByType(type);
+    let value;
+    if( metricDef.valueType === 'DISTRIBUTION' ) {
+      value = [];
+    } else {
+      value = 0;
+    }
+
+    metric = {key, labels, type, value, definition: metricDef}
+    if( !this.queue[type] ) this.queue[type] = [];
+    this.queue[type].push(metric);
+    return metric;
+  }
+
+  getDefinitionByType(type) {
+    return Object.values(config.metrics.definitions).find(item => item.type === type);
   }
 
   async _sendQueue() {
-    for( let name in this.values ) {
-      for( let key in this.values[name] ) {
-        let type = this.metrics[name].type;
-        let {value,labels} = this.values[name][key];
+    for( let type in this.queue ) {
+      if( this.queue[type].length === 0 ) return;
 
-        await this._send(type, labels, value);
-
-        this.values[name] = null;
-        break;
-      }
+      this._send(this.queue[type].shift());
     }
   }
 
-  async _send(type, labels, value) {
+  async _send(metric) {
+    let {type, labels, value} = metric;
+
+    // see config.metrics.pointValueMap for description about what the crap this is.
+    let metricType = this.getDefinitionByType(type);
+    let valueType = config.metrics.pointValueMap[metricType.valueType];
+
+    // calcs: https://cloud.google.com/monitoring/api/ref_v3/rest/v3/TypedValue#Distribution
+    if( Array.isArray(value) ) {
+      let bounds = metric.definition.bucketOptions.explicitBuckets.bounds;
+      let distribution = {
+        count : value.length,
+        mean : 0,
+        sumOfSquaredDeviation : 0,
+        bucketOptions : metric.definition.bucketOptions,
+        bucketCounts : bounds.map(item => 0)
+      }
+
+      value.forEach(v => {
+        distribution.mean += v;
+        for( let i = 0; i <= bounds.length; i++ ) {
+          if( bounds[i] > v ) {
+            distribution.bucketCounts[i] += 1;
+            break;
+          }
+        }
+      });
+      distribution.mean = distribution.mean / value.length;
+
+      value.forEach(v => {
+        distribution.sumOfSquaredDeviation += Math.pow(v - distribution.mean, 2);
+      });
+
+      // for some reason, some of this needs to be strings... I guess to support Int64?
+      distribution.count = distribution.count+'';
+      distribution.bucketCounts = distribution.bucketCounts.map(c => c+'');
+
+      value = distribution;
+    } else {
+      value = value+'';
+    }
+
+
     let dataPoint = {
       interval: {
         endTime: {
-          seconds: new Date().getTime() / 1000
+          seconds: Math.floor(Date.now() / 1000)
         }
       },
       value: {
-        int64Value: value+'',
-      },
-    };
+        [valueType]: value,
+      }
+    }
 
     let timeSeriesData = {
       metric: {type, labels},
@@ -118,7 +204,7 @@ class GCMetrics {
       timeSeries: [timeSeriesData],
     };
 
-    logger.info('sending metric', type, labels, value);
+    logger.info('sending metric', type, labels, dataPoint);
 
     // Writes time series data
     try {

--- a/elastic-search/package-lock.json
+++ b/elastic-search/package-lock.json
@@ -52,6 +52,25 @@
         "node": ">=10"
       }
     },
+    "node_modules/@google-cloud/common/node_modules/google-auth-library": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.12.0.tgz",
+      "integrity": "sha512-RS/whvFPMoF1hQNxnoVET3DWKPBt1Xgqe2rY0k+Jn7TNhoHlwdnSe7Rlcbo2Nub3Mt2lUVz26X65aDQrWp6x8w==",
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "fast-text-encoding": "^1.0.0",
+        "gaxios": "^4.0.0",
+        "gcp-metadata": "^4.2.0",
+        "gtoken": "^5.0.4",
+        "jws": "^4.0.0",
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@google-cloud/logging": {
       "version": "9.6.8",
       "resolved": "https://registry.npmjs.org/@google-cloud/logging/-/logging-9.6.8.tgz",
@@ -92,6 +111,25 @@
         "bunyan": "*"
       }
     },
+    "node_modules/@google-cloud/logging-bunyan/node_modules/google-auth-library": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.12.0.tgz",
+      "integrity": "sha512-RS/whvFPMoF1hQNxnoVET3DWKPBt1Xgqe2rY0k+Jn7TNhoHlwdnSe7Rlcbo2Nub3Mt2lUVz26X65aDQrWp6x8w==",
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "fast-text-encoding": "^1.0.0",
+        "gaxios": "^4.0.0",
+        "gcp-metadata": "^4.2.0",
+        "gtoken": "^5.0.4",
+        "jws": "^4.0.0",
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@google-cloud/logging/node_modules/dot-prop": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
@@ -104,6 +142,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@google-cloud/logging/node_modules/google-auth-library": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.12.0.tgz",
+      "integrity": "sha512-RS/whvFPMoF1hQNxnoVET3DWKPBt1Xgqe2rY0k+Jn7TNhoHlwdnSe7Rlcbo2Nub3Mt2lUVz26X65aDQrWp6x8w==",
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "fast-text-encoding": "^1.0.0",
+        "gaxios": "^4.0.0",
+        "gcp-metadata": "^4.2.0",
+        "gtoken": "^5.0.4",
+        "jws": "^4.0.0",
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@google-cloud/monitoring": {
@@ -172,6 +229,25 @@
         "snakeize": "^0.1.0",
         "stream-events": "^1.0.4",
         "xdg-basedir": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/google-auth-library": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.12.0.tgz",
+      "integrity": "sha512-RS/whvFPMoF1hQNxnoVET3DWKPBt1Xgqe2rY0k+Jn7TNhoHlwdnSe7Rlcbo2Nub3Mt2lUVz26X65aDQrWp6x8w==",
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "fast-text-encoding": "^1.0.0",
+        "gaxios": "^4.0.0",
+        "gcp-metadata": "^4.2.0",
+        "gtoken": "^5.0.4",
+        "jws": "^4.0.0",
+        "lru-cache": "^6.0.0"
       },
       "engines": {
         "node": ">=10"
@@ -978,25 +1054,6 @@
         "node": "*"
       }
     },
-    "node_modules/google-auth-library": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.11.0.tgz",
-      "integrity": "sha512-3S5jn2quRumvh9F/Ubf7GFrIq71HZ5a6vqosgdIu105kkk0WtSqc2jGCRqtWWOLRS8SX3AHACMOEDxhyWAQIcg==",
-      "dependencies": {
-        "arrify": "^2.0.0",
-        "base64-js": "^1.3.0",
-        "ecdsa-sig-formatter": "^1.0.11",
-        "fast-text-encoding": "^1.0.0",
-        "gaxios": "^4.0.0",
-        "gcp-metadata": "^4.2.0",
-        "gtoken": "^5.0.4",
-        "jws": "^4.0.0",
-        "lru-cache": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/google-gax": {
       "version": "2.29.5",
       "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-2.29.5.tgz",
@@ -1018,6 +1075,25 @@
       },
       "bin": {
         "compileProtos": "build/tools/compileProtos.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/google-gax/node_modules/google-auth-library": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.12.0.tgz",
+      "integrity": "sha512-RS/whvFPMoF1hQNxnoVET3DWKPBt1Xgqe2rY0k+Jn7TNhoHlwdnSe7Rlcbo2Nub3Mt2lUVz26X65aDQrWp6x8w==",
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "fast-text-encoding": "^1.0.0",
+        "gaxios": "^4.0.0",
+        "gcp-metadata": "^4.2.0",
+        "gtoken": "^5.0.4",
+        "jws": "^4.0.0",
+        "lru-cache": "^6.0.0"
       },
       "engines": {
         "node": ">=10"
@@ -2145,6 +2221,24 @@
         "google-auth-library": "^7.9.2",
         "retry-request": "^4.2.2",
         "teeny-request": "^7.0.0"
+      },
+      "dependencies": {
+        "google-auth-library": {
+          "version": "7.12.0",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.12.0.tgz",
+          "integrity": "sha512-RS/whvFPMoF1hQNxnoVET3DWKPBt1Xgqe2rY0k+Jn7TNhoHlwdnSe7Rlcbo2Nub3Mt2lUVz26X65aDQrWp6x8w==",
+          "requires": {
+            "arrify": "^2.0.0",
+            "base64-js": "^1.3.0",
+            "ecdsa-sig-formatter": "^1.0.11",
+            "fast-text-encoding": "^1.0.0",
+            "gaxios": "^4.0.0",
+            "gcp-metadata": "^4.2.0",
+            "gtoken": "^5.0.4",
+            "jws": "^4.0.0",
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "@google-cloud/logging": {
@@ -2176,6 +2270,22 @@
           "requires": {
             "is-obj": "^2.0.0"
           }
+        },
+        "google-auth-library": {
+          "version": "7.12.0",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.12.0.tgz",
+          "integrity": "sha512-RS/whvFPMoF1hQNxnoVET3DWKPBt1Xgqe2rY0k+Jn7TNhoHlwdnSe7Rlcbo2Nub3Mt2lUVz26X65aDQrWp6x8w==",
+          "requires": {
+            "arrify": "^2.0.0",
+            "base64-js": "^1.3.0",
+            "ecdsa-sig-formatter": "^1.0.11",
+            "fast-text-encoding": "^1.0.0",
+            "gaxios": "^4.0.0",
+            "gcp-metadata": "^4.2.0",
+            "gtoken": "^5.0.4",
+            "jws": "^4.0.0",
+            "lru-cache": "^6.0.0"
+          }
         }
       }
     },
@@ -2186,6 +2296,24 @@
       "requires": {
         "@google-cloud/logging": "^9.0.0",
         "google-auth-library": "^7.0.0"
+      },
+      "dependencies": {
+        "google-auth-library": {
+          "version": "7.12.0",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.12.0.tgz",
+          "integrity": "sha512-RS/whvFPMoF1hQNxnoVET3DWKPBt1Xgqe2rY0k+Jn7TNhoHlwdnSe7Rlcbo2Nub3Mt2lUVz26X65aDQrWp6x8w==",
+          "requires": {
+            "arrify": "^2.0.0",
+            "base64-js": "^1.3.0",
+            "ecdsa-sig-formatter": "^1.0.11",
+            "fast-text-encoding": "^1.0.0",
+            "gaxios": "^4.0.0",
+            "gcp-metadata": "^4.2.0",
+            "gtoken": "^5.0.4",
+            "jws": "^4.0.0",
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "@google-cloud/monitoring": {
@@ -2242,6 +2370,24 @@
         "snakeize": "^0.1.0",
         "stream-events": "^1.0.4",
         "xdg-basedir": "^4.0.0"
+      },
+      "dependencies": {
+        "google-auth-library": {
+          "version": "7.12.0",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.12.0.tgz",
+          "integrity": "sha512-RS/whvFPMoF1hQNxnoVET3DWKPBt1Xgqe2rY0k+Jn7TNhoHlwdnSe7Rlcbo2Nub3Mt2lUVz26X65aDQrWp6x8w==",
+          "requires": {
+            "arrify": "^2.0.0",
+            "base64-js": "^1.3.0",
+            "ecdsa-sig-formatter": "^1.0.11",
+            "fast-text-encoding": "^1.0.0",
+            "gaxios": "^4.0.0",
+            "gcp-metadata": "^4.2.0",
+            "gtoken": "^5.0.4",
+            "jws": "^4.0.0",
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "@grpc/grpc-js": {
@@ -2883,22 +3029,6 @@
         "path-is-absolute": "^1.0.0"
       }
     },
-    "google-auth-library": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.11.0.tgz",
-      "integrity": "sha512-3S5jn2quRumvh9F/Ubf7GFrIq71HZ5a6vqosgdIu105kkk0WtSqc2jGCRqtWWOLRS8SX3AHACMOEDxhyWAQIcg==",
-      "requires": {
-        "arrify": "^2.0.0",
-        "base64-js": "^1.3.0",
-        "ecdsa-sig-formatter": "^1.0.11",
-        "fast-text-encoding": "^1.0.0",
-        "gaxios": "^4.0.0",
-        "gcp-metadata": "^4.2.0",
-        "gtoken": "^5.0.4",
-        "jws": "^4.0.0",
-        "lru-cache": "^6.0.0"
-      }
-    },
     "google-gax": {
       "version": "2.29.5",
       "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-2.29.5.tgz",
@@ -2917,6 +3047,24 @@
         "proto3-json-serializer": "^0.1.8",
         "protobufjs": "6.11.2",
         "retry-request": "^4.0.0"
+      },
+      "dependencies": {
+        "google-auth-library": {
+          "version": "7.12.0",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.12.0.tgz",
+          "integrity": "sha512-RS/whvFPMoF1hQNxnoVET3DWKPBt1Xgqe2rY0k+Jn7TNhoHlwdnSe7Rlcbo2Nub3Mt2lUVz26X65aDQrWp6x8w==",
+          "requires": {
+            "arrify": "^2.0.0",
+            "base64-js": "^1.3.0",
+            "ecdsa-sig-formatter": "^1.0.11",
+            "fast-text-encoding": "^1.0.0",
+            "gaxios": "^4.0.0",
+            "gcp-metadata": "^4.2.0",
+            "gtoken": "^5.0.4",
+            "jws": "^4.0.0",
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "google-p12-pem": {


### PR DESCRIPTION
This `should` be good to go;  leaving this service on will automatically index all registered wordpress post types (currently: 'post', 'page', 'book') and libguides at 5am, into elastic search.  All wired up to dashboard & alerts in GC.  Includes the first pass out the three custom metrics I am proposing to use.