### PR TITLE
adding consistent sort by date to es records

### DIFF
--- a/elastic-search/index.js
+++ b/elastic-search/index.js
@@ -25,7 +25,7 @@ app.get('/reindex', async (req, res) => {
   }
 
   await wp.reharvestAll();
-  await gcs.run();
+  await gcs.run({recordAge:false});
   reindexRunning = false;
 });
 

--- a/elastic-search/lib/config.js
+++ b/elastic-search/lib/config.js
@@ -27,7 +27,12 @@ const config = {
   },
 
   wordpress : {
-    types : WP_TYPES || ['post', 'page', 'location']
+    types : WP_TYPES || ['post', 'page', 'location', 'exhibits']
+  },
+
+  indexer : {
+    // be default the sortByDate will be set to modified date, unless in this array
+    sortByDateCreated : ['post', 'exhibits']
   },
 
   instance : {

--- a/elastic-search/lib/harvest/gcs.js
+++ b/elastic-search/lib/harvest/gcs.js
@@ -23,9 +23,13 @@ class GCSHarvest {
     await elasticSearch.ensureIndex();
   }
 
-  async run() {
+  async run(opts={}) {
     let indexedData = await storage.jsonDownload(config.storage.indexFile);
-    this.recordAge(indexedData.data, indexedData.metadata.updated, indexedData.data.id);
+
+    if( opts.recordAge !== false ) {
+      this.recordAge(indexedData.data, indexedData.metadata.updated, indexedData.data.id);
+    }
+
     indexedData = indexedData.data;
 
     let record;

--- a/elastic-search/lib/harvest/wp.js
+++ b/elastic-search/lib/harvest/wp.js
@@ -42,15 +42,15 @@ class WPHarvest {
 
     let resp = await mysql.query(`select ID from wp_posts where post_status = 'publish' and post_type IN (?)`, [this.POST_TYPES]);
     for( let post of resp.results ) {
-      await this.harvestPost(post.ID, true);
+      await this.harvestPost(post.ID, {recordAge: false});
     }
   }
 
-  async harvestPost(postId, reharvest=false) {
+  async harvestPost(postId, opts={}) {
     let post = {};
 
     try {
-      let qResp = await mysql.query(`select ID, post_type, post_content, post_name, post_title, post_status, post_modified_gmt from wp_posts where ID=${postId}`);
+      let qResp = await mysql.query(`select ID, post_type, post_content, post_name, post_title, post_status, post_date_gmt, post_modified_gmt from wp_posts where ID=${postId}`);
       
       // post doesn't exists
       // TODO: delete from elastic search
@@ -100,7 +100,7 @@ class WPHarvest {
       } catch(e) {}
 
       // record age of record about to be indexed, unless its a reharvest
-      if( reharvest !== true ) {
+      if( opts.recordAge !== false ) {
         this.recordAge(post);
       }
 

--- a/elastic-search/lib/schema.json
+++ b/elastic-search/lib/schema.json
@@ -89,6 +89,10 @@
 
     "updated" : {
       "type" : "date"
+    },
+
+    "sortByDate" : {
+      "type" : "date"
     }
     
   }

--- a/elastic-search/lib/transform/database.js
+++ b/elastic-search/lib/transform/database.js
@@ -1,4 +1,5 @@
 import crypto from 'crypto';
+import {setDates} from './utils.js';
 
 function transformDatabase(database) {
   database.id = 'database-'+database.id;
@@ -30,6 +31,8 @@ function transformDatabase(database) {
   if( database.url ) {
     delete database.url;
   }
+
+  setDates(database);
 
   database.md5 = crypto.createHash('md5').update(JSON.stringify(database)).digest('hex')
 

--- a/elastic-search/lib/transform/libguide.js
+++ b/elastic-search/lib/transform/libguide.js
@@ -1,4 +1,5 @@
 import crypto from 'crypto';
+import {setDates} from './utils.js';
 
 function transformRecord(libguideSource, libguide, parentRecord) {
   let record = parentRecord || {};
@@ -15,7 +16,14 @@ function transformRecord(libguideSource, libguide, parentRecord) {
       .replace(/: Home$/i, '')
       .replace(/^Research Guides:/i, '' )
       .trim();
-    record.description = libguide.dublinCore?.description;
+
+    if( libguide.dublinCore ) {
+      record.description = libguide.dublinCore.description;
+      record.created = libguide.dublinCore['date.created'];
+      record.modified = libguide.dublinCore['date.modified'];
+      setDates(record);
+    }
+
   } else {
     if( !record.children ) record.children = [];
     record.children.push(libguide.url);

--- a/elastic-search/lib/transform/utils.js
+++ b/elastic-search/lib/transform/utils.js
@@ -1,0 +1,16 @@
+import config from '../config.js';
+
+function setDates(record, createProp='created', modifiedProp='modified') {
+  record.created = fixDate(record[createProp]);
+  record.modified = fixDate(record[modifiedProp]);
+
+  let sortByCreated = config.indexer.sortByDateCreated.includes(record.type);
+  record.sortByDate = record[sortByCreated ? 'created' : 'modified'];
+}
+
+function fixDate(date) {
+  if( !date ) return date;
+  return new Date(date).toISOString();
+}
+
+export {setDates}

--- a/elastic-search/lib/transform/wordpress.js
+++ b/elastic-search/lib/transform/wordpress.js
@@ -3,6 +3,7 @@ import striptags from 'striptags';
 import { parse } from '@wordpress/block-serialization-default-parser';
 import htmlEntities from 'html-entities';
 import { JSDOM } from 'jsdom';
+import {setDates} from './utils.js';
 
 function transformRecord(post) {
   let record = {
@@ -10,11 +11,15 @@ function transformRecord(post) {
     title : post.post_title,
     type : post.post_type,
     description : post.post_name,
+    created : post.post_date_gmt,
+    modified : post.post_modified_gmt,
     content : '',
     blocks : {},
     subjects : [],
     tags : []
   };
+
+  setDates(record);
 
   // set categories (we call them subjects) and tags
   for( let term of post.terms ) {
@@ -58,6 +63,19 @@ function parseBlocks(record, blocks) {
     }
     record.blocks[blockName].push(block.attrs);
   }
+}
+
+/**
+ * @method fixDate
+ * @description dublin core dates seem to be set like: Aug 6, 2013.
+ * We need to fix.
+ * 
+ * @param {String} date 
+ * @returns {String}
+ */
+ function fixDate(date) {
+  if( !date ) return date;
+  return new Date(date).toISOString();
 }
 
 export default transformRecord;


### PR DESCRIPTION
Creates a `sortByDate` field in elastic search record.  The config property `config.indexer.sortByDateCreated` sets which types should use the `created` date as the `sortByDate` property, otherwise the `modified` date is used.  All records have a standard `created` and `modified` date field as well, regardless of type.

Note, this PR does not include integration into search UI.  Just indexing and schema updates.